### PR TITLE
dedupe for setSingleOr.. func

### DIFF
--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -311,11 +311,12 @@ func (c *RulesetCreator) setSingleOrOR(ids ...string) (string, error) {
 		)
 	}
 
-	if len(ids) == 1 {
-		return ids[0], nil
+	deduped := utils.Dedupe(ids)
+	if len(deduped) == 1 {
+		return deduped[0], nil
 	}
 
-	return c.SetOr(ids...)
+	return c.SetOr(deduped...)
 }
 
 func (c *RulesetCreator) setSingleOrXOR(ids ...string) (string, error) {
@@ -326,11 +327,12 @@ func (c *RulesetCreator) setSingleOrXOR(ids ...string) (string, error) {
 		)
 	}
 
-	if len(ids) == 1 {
-		return ids[0], nil
+	deduped := utils.Dedupe(ids)
+	if len(deduped) == 1 {
+		return deduped[0], nil
 	}
 
-	return c.SetXor(ids...)
+	return c.SetXor(deduped...)
 }
 
 func (c *RulesetCreator) setSingleOrAnd(ids ...string) (string, error) {
@@ -341,11 +343,12 @@ func (c *RulesetCreator) setSingleOrAnd(ids ...string) (string, error) {
 		)
 	}
 
-	if len(ids) == 1 {
-		return ids[0], nil
+	deduped := utils.Dedupe(ids)
+	if len(deduped) == 1 {
+		return deduped[0], nil
 	}
 
-	return c.SetAnd(ids...)
+	return c.SetAnd(deduped...)
 }
 
 func (c *RulesetCreator) createAssumeConstraints() error {

--- a/puan/ruleset_creator_test.go
+++ b/puan/ruleset_creator_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/ourstudio-se/puan-sdk-go/internal/fake"
+	"github.com/ourstudio-se/puan-sdk-go/puanerror"
 )
 
 func Test_RulesetCreator_newTimeBoundVariable_givenTimeEnabled_andValidPeriod(t *testing.T) {
@@ -173,4 +174,52 @@ func Test_RulesetCreator_AssumeInPeriod_givenDifferentPeriod_shouldAddTimeBoundV
 
 	assert.NotContains(t, creator.assumedVariables, "itemX")
 	assert.Contains(t, creator.timeBoundAssumedVariables.ids(), "itemX")
+}
+
+func Test_RulesetCreator_setSingleOrOR_givenNoIDs_shouldReturnError(t *testing.T) {
+	creator := NewRulesetCreator()
+	_, err := creator.setSingleOrOR([]string{}...)
+
+	assert.ErrorIs(t, err, puanerror.InvalidArgument)
+}
+
+func Test_RulesetCreator_setSingleOrOR_givenDuplicatedIDs_shouldReturnID(t *testing.T) {
+	code := fake.New[string]()
+	creator := NewRulesetCreator()
+	got, err := creator.setSingleOrOR(code, code)
+
+	assert.NoError(t, err)
+	assert.Equal(t, code, got)
+}
+
+func Test_RulesetCreator_setSingleOrXOR_givenNoIDs_shouldReturnError(t *testing.T) {
+	creator := NewRulesetCreator()
+	_, err := creator.setSingleOrXOR([]string{}...)
+
+	assert.ErrorIs(t, err, puanerror.InvalidArgument)
+}
+
+func Test_RulesetCreator_setSingleOrXOR_givenDuplicatedIDs_shouldReturnID(t *testing.T) {
+	code := fake.New[string]()
+	creator := NewRulesetCreator()
+	got, err := creator.setSingleOrXOR(code, code)
+
+	assert.NoError(t, err)
+	assert.Equal(t, code, got)
+}
+
+func Test_RulesetCreator_setSingleOrAND_givenNoIDs_shouldReturnError(t *testing.T) {
+	creator := NewRulesetCreator()
+	_, err := creator.setSingleOrAnd([]string{}...)
+
+	assert.ErrorIs(t, err, puanerror.InvalidArgument)
+}
+
+func Test_RulesetCreator_setSingleOrAND_givenDuplicatedIDs_shouldReturnID(t *testing.T) {
+	code := fake.New[string]()
+	creator := NewRulesetCreator()
+	got, err := creator.setSingleOrAnd(code, code)
+
+	assert.NoError(t, err)
+	assert.Equal(t, code, got)
 }


### PR DESCRIPTION
# Description

Dedupe ids for `setSingleOR...`

# How Has This Been Tested?
- [x] Unit tests

# Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Tests are added for relevant functions
- [x] New and existing unit tests pass locally with my changes