### PR TITLE
Feature/225/gaps in allowed time

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10
+          version: v2.11
           args: --timeout=5m
 
   govulncheck:

--- a/puan/periods_test.go
+++ b/puan/periods_test.go
@@ -91,6 +91,30 @@ func Test_Period_overlaps(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "a contains b",
+			a: Period{
+				from: newTestTime("2024-01-01T00:00:00Z"),
+				to:   newTestTime("2024-01-20T00:00:00Z"),
+			},
+			b: Period{
+				from: newTestTime("2024-01-10T00:00:00Z"),
+				to:   newTestTime("2024-01-15T00:00:00Z"),
+			},
+			expected: true,
+		},
+		{
+			name: "b contains a",
+			a: Period{
+				from: newTestTime("2024-01-10T00:00:00Z"),
+				to:   newTestTime("2024-01-15T00:00:00Z"),
+			},
+			b: Period{
+				from: newTestTime("2024-01-01T00:00:00Z"),
+				to:   newTestTime("2024-01-20T00:00:00Z"),
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -816,7 +840,12 @@ func Test_passed_givenBeforeTimestamp_shouldReturnNoVariables(t *testing.T) {
 func newTestTime(value string) time.Time {
 	t, err := time.Parse(time.RFC3339, value)
 	if err != nil {
+		t, err = time.Parse(time.DateOnly, value)
+	}
+
+	if err != nil {
 		panic(err)
 	}
+
 	return t
 }

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -18,6 +18,7 @@ type RulesetCreator struct {
 	assumedVariables   []string
 
 	period                      *Period
+	forbiddenPeriods            []Period
 	timeBoundAssumedVariables   TimeBoundVariables
 	timeBoundPreferredVariables TimeBoundVariables
 }
@@ -198,6 +199,19 @@ func (c *RulesetCreator) EnableTime(
 	return nil
 }
 
+func (c *RulesetCreator) ForbidPeriod(
+	from, to time.Time,
+) error {
+	period, err := NewPeriod(from, to)
+	if err != nil {
+		return err
+	}
+
+	c.forbiddenPeriods = append(c.forbiddenPeriods, period)
+
+	return nil
+}
+
 func (c *RulesetCreator) Create() (Ruleset, error) {
 	periodVariables, err := c.newPeriodVariables()
 	if err != nil {
@@ -290,6 +304,7 @@ func (c *RulesetCreator) timeDisabled() bool {
 func (c *RulesetCreator) periods() []Period {
 	periods := []Period{}
 	periods = append(periods, *c.period)
+	periods = append(periods, c.forbiddenPeriods...)
 	periods = append(periods, c.timeBoundAssumedVariables.periods()...)
 	periods = append(periods, c.timeBoundPreferredVariables.periods()...)
 	return periods
@@ -321,6 +336,18 @@ func (c *RulesetCreator) createPeriodConstraints(periodVariables TimeBoundVariab
 		return err
 	}
 	constraintIDs = append(constraintIDs, exactlyOnePeriod)
+
+	for _, forbiddenPeriod := range c.forbiddenPeriods {
+		for _, periodVariable := range periodVariables {
+			if forbiddenPeriod.contains(periodVariable.period) {
+				constraintID, err := c.SetNot(periodVariable.variable)
+				if err != nil {
+					return err
+				}
+				constraintIDs = append(constraintIDs, constraintID)
+			}
+		}
+	}
 
 	return c.Assume(constraintIDs...)
 }

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -207,6 +207,25 @@ func (c *RulesetCreator) ForbidPeriod(
 		return err
 	}
 
+	if !c.period.contains(period) {
+		return errors.Errorf(
+			"%w: period %v is outside of enabled period %v",
+			puanerror.InvalidArgument,
+			period,
+			*c.period,
+		)
+	}
+
+	for _, existingForbiddenPeriod := range c.forbiddenPeriods {
+		if existingForbiddenPeriod.overlaps(period) {
+			return errors.Errorf(
+				"period %v overlaps with existing forbidden period %v",
+				period,
+				existingForbiddenPeriod,
+			)
+		}
+	}
+
 	c.forbiddenPeriods = append(c.forbiddenPeriods, period)
 
 	return nil

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -349,26 +349,35 @@ func (c *RulesetCreator) createPeriodConstraints(
 func (c *RulesetCreator) createForbiddenPeriodConstraints(
 	periodVariables TimeBoundVariables,
 ) error {
-	var forbiddenPeriodIDs []string
-	for _, periodVariable := range periodVariables {
-		for _, forbiddenPeriod := range c.forbiddenPeriods {
-			if forbiddenPeriod.contains(periodVariable.period) {
-				forbiddenPeriodIDs = append(forbiddenPeriodIDs, periodVariable.variable)
-				break
-			}
-		}
-	}
+	forbidden := c.findForbiddenPeriods(periodVariables)
 
-	if len(forbiddenPeriodIDs) == 0 {
+	if len(forbidden) == 0 {
 		return nil
 	}
 
-	constraintID, err := c.SetNot(forbiddenPeriodIDs...)
+	constraintID, err := c.SetNot(forbidden.ids()...)
 	if err != nil {
 		return err
 	}
 
 	return c.Assume(constraintID)
+}
+
+func (c *RulesetCreator) findForbiddenPeriods(
+	periodVariables TimeBoundVariables,
+) TimeBoundVariables {
+	return utils.Filter(periodVariables, c.isForbiddenPeriod)
+}
+
+func (c *RulesetCreator) isForbiddenPeriod(
+	periodVariable TimeBoundVariable,
+) bool {
+	for _, forbiddenPeriod := range c.forbiddenPeriods {
+		if forbiddenPeriod.contains(periodVariable.period) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *RulesetCreator) createPreferredsManyInPeriods(periodVariables TimeBoundVariables) error {

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -213,7 +213,7 @@ func (c *RulesetCreator) ForbidPeriod(
 }
 
 func (c *RulesetCreator) Create() (Ruleset, error) {
-	periodVariables, err := c.newPeriodVariables()
+	periodVariables, err := c.createPeriodVariables()
 	if err != nil {
 		return Ruleset{}, err
 	}
@@ -272,7 +272,7 @@ func (c *RulesetCreator) findDependantVariables() []string {
 	return utils.Union(constraintVariables, assumedVariables)
 }
 
-func (c *RulesetCreator) newPeriodVariables() (TimeBoundVariables, error) {
+func (c *RulesetCreator) createPeriodVariables() (TimeBoundVariables, error) {
 	if c.timeDisabled() {
 		return nil, nil
 	}
@@ -281,17 +281,14 @@ func (c *RulesetCreator) newPeriodVariables() (TimeBoundVariables, error) {
 		c.periods(),
 	)
 
-	// Create variable for each period
-	periodVariables := make(TimeBoundVariables, len(nonOverlappingPeriods))
-	for i, period := range nonOverlappingPeriods {
-		period := TimeBoundVariable{
-			variable: fmt.Sprintf("period_%d", i),
-			period:   period,
-		}
-		periodVariables[i] = period
-		if err := c.model.AddPrimitives(period.variable); err != nil {
-			return nil, err
-		}
+	periodVariables, err := c.newPeriodVariables(nonOverlappingPeriods)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.model.AddPrimitives(periodVariables.ids()...)
+	if err != nil {
+		return nil, err
 	}
 
 	return periodVariables, nil
@@ -299,6 +296,32 @@ func (c *RulesetCreator) newPeriodVariables() (TimeBoundVariables, error) {
 
 func (c *RulesetCreator) timeDisabled() bool {
 	return c.period == nil
+}
+
+func (c *RulesetCreator) newPeriodVariables(
+	periods []Period,
+) (TimeBoundVariables, error) {
+	for i := range len(periods) - 1 {
+		notTouching := !periods[i].to.Equal(periods[i+1].from)
+		if notTouching {
+			return nil, errors.Errorf(
+				"periods %v and %v are not touching",
+				periods[i],
+				periods[i+1],
+			)
+		}
+	}
+
+	periodVariables := make(TimeBoundVariables, len(periods))
+	for i, period := range periods {
+		periodVariable := TimeBoundVariable{
+			variable: fmt.Sprintf("period_%d", i),
+			period:   period,
+		}
+		periodVariables[i] = periodVariable
+	}
+
+	return periodVariables, nil
 }
 
 func (c *RulesetCreator) periods() []Period {

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -52,8 +52,8 @@ func (c *RulesetCreator) SetOr(variables ...string) (string, error) {
 	return c.model.SetOr(variables...)
 }
 
-func (c *RulesetCreator) SetNot(variable ...string) (string, error) {
-	return c.model.SetNot(variable...)
+func (c *RulesetCreator) SetNot(variables ...string) (string, error) {
+	return c.model.SetNot(variables...)
 }
 
 func (c *RulesetCreator) SetImply(condition, consequence string) (string, error) {
@@ -310,7 +310,9 @@ func (c *RulesetCreator) periods() []Period {
 	return periods
 }
 
-func (c *RulesetCreator) createPeriodConstraints(periodVariables TimeBoundVariables) error {
+func (c *RulesetCreator) createPeriodConstraints(
+	periodVariables TimeBoundVariables,
+) error {
 	if c.timeDisabled() {
 		return nil
 	}
@@ -330,6 +332,10 @@ func (c *RulesetCreator) createPeriodConstraints(periodVariables TimeBoundVariab
 		constraintIDs = append(constraintIDs, constraintID)
 	}
 
+	if err := c.createForbiddenPeriodConstraints(periodVariables); err != nil {
+		return err
+	}
+
 	// Choose exactly one period
 	exactlyOnePeriod, err := c.setSingleOrXOR(periodVariables.ids()...)
 	if err != nil {
@@ -337,19 +343,32 @@ func (c *RulesetCreator) createPeriodConstraints(periodVariables TimeBoundVariab
 	}
 	constraintIDs = append(constraintIDs, exactlyOnePeriod)
 
-	for _, forbiddenPeriod := range c.forbiddenPeriods {
-		for _, periodVariable := range periodVariables {
+	return c.Assume(constraintIDs...)
+}
+
+func (c *RulesetCreator) createForbiddenPeriodConstraints(
+	periodVariables TimeBoundVariables,
+) error {
+	var forbiddenPeriodIDs []string
+	for _, periodVariable := range periodVariables {
+		for _, forbiddenPeriod := range c.forbiddenPeriods {
 			if forbiddenPeriod.contains(periodVariable.period) {
-				constraintID, err := c.SetNot(periodVariable.variable)
-				if err != nil {
-					return err
-				}
-				constraintIDs = append(constraintIDs, constraintID)
+				forbiddenPeriodIDs = append(forbiddenPeriodIDs, periodVariable.variable)
+				break
 			}
 		}
 	}
 
-	return c.Assume(constraintIDs...)
+	if len(forbiddenPeriodIDs) == 0 {
+		return nil
+	}
+
+	constraintID, err := c.SetNot(forbiddenPeriodIDs...)
+	if err != nil {
+		return err
+	}
+
+	return c.Assume(constraintID)
 }
 
 func (c *RulesetCreator) createPreferredsManyInPeriods(periodVariables TimeBoundVariables) error {

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -226,7 +226,8 @@ func (c *RulesetCreator) ForbidPeriod(
 	for _, existingForbiddenPeriod := range c.forbiddenPeriods {
 		if existingForbiddenPeriod.overlaps(period) {
 			return errors.Errorf(
-				"period %v overlaps with existing forbidden period %v",
+				"%w: period %v overlaps with existing forbidden period %v",
+				puanerror.InvalidArgument,
 				period,
 				existingForbiddenPeriod,
 			)

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -223,7 +223,7 @@ func (c *RulesetCreator) Create() (Ruleset, error) {
 		return Ruleset{}, err
 	}
 
-	err = c.createPreferredsManyInPeriods(periodVariables)
+	err = c.createPeriodPreferreds(periodVariables)
 	if err != nil {
 		return Ruleset{}, err
 	}
@@ -317,6 +317,24 @@ func (c *RulesetCreator) createPeriodConstraints(
 		return nil
 	}
 
+	if err := c.createForbiddenPeriodsConstraint(periodVariables); err != nil {
+		return err
+	}
+
+	if err := c.createTimeBoundAssumeConstraints(periodVariables); err != nil {
+		return err
+	}
+
+	if err := c.createExactlyOnePeriodConstraint(periodVariables); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *RulesetCreator) createTimeBoundAssumeConstraints(
+	periodVariables TimeBoundVariables,
+) error {
 	groupedByPeriods, err := groupByPeriods(periodVariables, c.timeBoundAssumedVariables)
 	if err != nil {
 		return err
@@ -332,21 +350,10 @@ func (c *RulesetCreator) createPeriodConstraints(
 		constraintIDs = append(constraintIDs, constraintID)
 	}
 
-	if err := c.createForbiddenPeriodConstraints(periodVariables); err != nil {
-		return err
-	}
-
-	// Choose exactly one period
-	exactlyOnePeriod, err := c.setSingleOrXOR(periodVariables.ids()...)
-	if err != nil {
-		return err
-	}
-	constraintIDs = append(constraintIDs, exactlyOnePeriod)
-
 	return c.Assume(constraintIDs...)
 }
 
-func (c *RulesetCreator) createForbiddenPeriodConstraints(
+func (c *RulesetCreator) createForbiddenPeriodsConstraint(
 	periodVariables TimeBoundVariables,
 ) error {
 	forbidden := c.findForbiddenPeriods(periodVariables)
@@ -380,7 +387,17 @@ func (c *RulesetCreator) isForbiddenPeriod(
 	return false
 }
 
-func (c *RulesetCreator) createPreferredsManyInPeriods(periodVariables TimeBoundVariables) error {
+func (c *RulesetCreator) createExactlyOnePeriodConstraint(
+	periodVariables TimeBoundVariables,
+) error {
+	exactlyOnePeriod, err := c.setSingleOrXOR(periodVariables.ids()...)
+	if err != nil {
+		return err
+	}
+	return c.Assume(exactlyOnePeriod)
+}
+
+func (c *RulesetCreator) createPeriodPreferreds(periodVariables TimeBoundVariables) error {
 	if c.timeDisabled() {
 		return nil
 	}

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -158,7 +158,7 @@ func (c *RulesetCreator) newTimeBoundVariable(
 	id string,
 	from, to time.Time,
 ) (TimeBoundVariable, error) {
-	if c.period == nil {
+	if c.timeDisabled() {
 		return TimeBoundVariable{}, errors.Errorf(
 			"%w: time support not enabled. Call EnableTime() first",
 			puanerror.InvalidOperation,
@@ -202,6 +202,13 @@ func (c *RulesetCreator) EnableTime(
 func (c *RulesetCreator) ForbidPeriod(
 	from, to time.Time,
 ) error {
+	if c.timeDisabled() {
+		return errors.Errorf(
+			"%w: time support not enabled. Call EnableTime() first",
+			puanerror.InvalidOperation,
+		)
+	}
+
 	period, err := NewPeriod(from, to)
 	if err != nil {
 		return err

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -405,6 +405,10 @@ func (c *RulesetCreator) findForbiddenPeriods(
 	return utils.Filter(periodVariables, c.isForbiddenPeriod)
 }
 
+// A `periodVariable` is assumed to be either contained
+// in a forbidden period, or completely outside of it.
+// We don't expect any period variables to have partial
+// overlap with a forbidden period.
 func (c *RulesetCreator) isForbiddenPeriod(
 	periodVariable TimeBoundVariable,
 ) bool {

--- a/puan/ruleset_creator.go
+++ b/puan/ruleset_creator.go
@@ -326,21 +326,21 @@ func (c *RulesetCreator) timeDisabled() bool {
 }
 
 func (c *RulesetCreator) newPeriodVariables(
-	periods []Period,
+	orderedPeriods []Period,
 ) (TimeBoundVariables, error) {
-	for i := range len(periods) - 1 {
-		notTouching := !periods[i].to.Equal(periods[i+1].from)
+	for i := range len(orderedPeriods) - 1 {
+		notTouching := !orderedPeriods[i].to.Equal(orderedPeriods[i+1].from)
 		if notTouching {
 			return nil, errors.Errorf(
 				"periods %v and %v are not touching",
-				periods[i],
-				periods[i+1],
+				orderedPeriods[i],
+				orderedPeriods[i+1],
 			)
 		}
 	}
 
-	periodVariables := make(TimeBoundVariables, len(periods))
-	for i, period := range periods {
+	periodVariables := make(TimeBoundVariables, len(orderedPeriods))
+	for i, period := range orderedPeriods {
 		periodVariable := TimeBoundVariable{
 			variable: fmt.Sprintf("period_%d", i),
 			period:   period,
@@ -382,27 +382,6 @@ func (c *RulesetCreator) createPeriodConstraints(
 	return nil
 }
 
-func (c *RulesetCreator) createTimeBoundAssumeConstraints(
-	periodVariables TimeBoundVariables,
-) error {
-	groupedByPeriods, err := groupByPeriods(periodVariables, c.timeBoundAssumedVariables)
-	if err != nil {
-		return err
-	}
-
-	var constraintIDs []string
-	for serializedPeriodIDs, assumedIDs := range groupedByPeriods {
-		periodIDs := serializedPeriodIDs.ids()
-		constraintID, err := c.setTimeBoundConstraint(periodIDs, assumedIDs)
-		if err != nil {
-			return err
-		}
-		constraintIDs = append(constraintIDs, constraintID)
-	}
-
-	return c.Assume(constraintIDs...)
-}
-
 func (c *RulesetCreator) createForbiddenPeriodsConstraint(
 	periodVariables TimeBoundVariables,
 ) error {
@@ -435,6 +414,27 @@ func (c *RulesetCreator) isForbiddenPeriod(
 		}
 	}
 	return false
+}
+
+func (c *RulesetCreator) createTimeBoundAssumeConstraints(
+	periodVariables TimeBoundVariables,
+) error {
+	groupedByPeriods, err := groupByPeriods(periodVariables, c.timeBoundAssumedVariables)
+	if err != nil {
+		return err
+	}
+
+	var constraintIDs []string
+	for serializedPeriodIDs, assumedIDs := range groupedByPeriods {
+		periodIDs := serializedPeriodIDs.ids()
+		constraintID, err := c.setTimeBoundConstraint(periodIDs, assumedIDs)
+		if err != nil {
+			return err
+		}
+		constraintIDs = append(constraintIDs, constraintID)
+	}
+
+	return c.Assume(constraintIDs...)
 }
 
 func (c *RulesetCreator) createExactlyOnePeriodConstraint(

--- a/puan/ruleset_creator_test.go
+++ b/puan/ruleset_creator_test.go
@@ -391,3 +391,114 @@ func Test_AddPrimitives_givenPrimitiveWithoutPeriodPrefix_shouldReturnNoError(t 
 	err := creator.AddPrimitives(fake.New[string]())
 	assert.NoError(t, err)
 }
+
+func Test_RulesetCreator_newPeriodVariables_givenValidPeriods_shouldReturnPeriodVariables(
+	t *testing.T,
+) {
+	periods := []Period{
+		{
+			from: newTestTime("2024-01-01"),
+			to:   newTestTime("2024-01-05"),
+		},
+		{
+			from: newTestTime("2024-01-05"),
+			to:   newTestTime("2024-01-10"),
+		},
+		{
+			from: newTestTime("2024-01-10"),
+			to:   newTestTime("2024-01-15"),
+		},
+	}
+
+	creator := RulesetCreator{}
+	periodVariables, err := creator.newPeriodVariables(periods)
+
+	assert.NoError(t, err)
+	want := TimeBoundVariables{
+		{
+			variable: "period_0",
+			period:   periods[0],
+		},
+		{
+			variable: "period_1",
+			period:   periods[1],
+		},
+		{
+			variable: "period_2",
+			period:   periods[2],
+		},
+	}
+	assert.Equal(t, want, periodVariables)
+}
+
+func Test_RulesetCreator_newPeriodVariables_givenInvalidPeriods_shouldReturnError(t *testing.T) {
+	type testCase struct {
+		name    string
+		periods []Period
+	}
+
+	cases := []testCase{
+		{
+			name: "given gaps",
+			periods: []Period{
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-05"),
+				},
+				{
+					from: newTestTime("2024-01-10"),
+					to:   newTestTime("2024-01-15"),
+				},
+			},
+		},
+		{
+			name: "given overlaps",
+			periods: []Period{
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-10"),
+				},
+				{
+					from: newTestTime("2024-01-05"),
+					to:   newTestTime("2024-01-15"),
+				},
+			},
+		},
+		{
+			name: "given duplicates",
+			periods: []Period{
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-10"),
+				},
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-10"),
+				},
+			},
+		},
+		{
+			name: "not sorted",
+			periods: []Period{
+				{
+					from: newTestTime("2024-01-05"),
+					to:   newTestTime("2024-01-10"),
+				},
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-05"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			creator := RulesetCreator{}
+
+			_, err := creator.newPeriodVariables(tt.periods)
+
+			assert.Error(t, err)
+		})
+	}
+}

--- a/puan/ruleset_creator_test.go
+++ b/puan/ruleset_creator_test.go
@@ -176,6 +176,77 @@ func Test_RulesetCreator_AssumeInPeriod_givenDifferentPeriod_shouldAddTimeBoundV
 	assert.Contains(t, creator.timeBoundAssumedVariables.ids(), "itemX")
 }
 
+func Test_RulesetCreator_ForbidPeriod_givenValidPeriod_shouldAddPeriod(t *testing.T) {
+	creator := RulesetCreator{
+		period: &Period{
+			from: newTestTime("2024-01-01"),
+			to:   newTestTime("2024-01-31"),
+		},
+	}
+
+	forbiddenFrom := newTestTime("2024-01-10")
+	forbiddenTo := newTestTime("2024-01-15")
+
+	err := creator.ForbidPeriod(forbiddenFrom, forbiddenTo)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []Period{
+		{
+			from: forbiddenFrom,
+			to:   forbiddenTo,
+		},
+	}, creator.forbiddenPeriods)
+}
+
+func Test_RulesetCreator_ForbidPeriod_givenErrorCases_shouldReturnError(t *testing.T) {
+	type testCase struct {
+		name             string
+		from             time.Time
+		to               time.Time
+		forbiddenPeriods []Period
+	}
+
+	cases := []testCase{
+		{
+			name: "from after to",
+			from: newTestTime("2024-01-10"),
+			to:   newTestTime("2024-01-05"),
+		},
+		{
+			name: "outside of enabled period",
+			from: newTestTime("2023-12-20"),
+			to:   newTestTime("2023-12-25"),
+		},
+		{
+			name: "overlaps with existing forbidden period",
+			from: newTestTime("2024-01-14"),
+			to:   newTestTime("2024-01-20"),
+			forbiddenPeriods: []Period{
+				{
+					from: newTestTime("2024-01-10"),
+					to:   newTestTime("2024-01-15"),
+				},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			creator := RulesetCreator{
+				period: &Period{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-31"),
+				},
+				forbiddenPeriods: tt.forbiddenPeriods,
+			}
+
+			err := creator.ForbidPeriod(tt.from, tt.to)
+
+			assert.Error(t, err)
+		})
+	}
+}
+
 func Test_RulesetCreator_setSingleOrOR_givenNoIDs_shouldReturnError(t *testing.T) {
 	creator := NewRulesetCreator()
 	_, err := creator.setSingleOrOR([]string{}...)

--- a/puan/ruleset_creator_test.go
+++ b/puan/ruleset_creator_test.go
@@ -474,7 +474,8 @@ func Test_AddPrimitives_givenPrimitiveWithoutPeriodPrefix_shouldReturnNoError(t 
 	assert.NoError(t, err)
 }
 
-func Test_RulesetCreator_newPeriodVariables_givenValidPeriods_shouldReturnPeriodVariables(
+// nolint:lll
+func Test_RulesetCreator_newPeriodVariables_givenTouchingAndOrderedPeriods_shouldReturnPeriodVariables(
 	t *testing.T,
 ) {
 	periods := []Period{

--- a/puan/ruleset_creator_test.go
+++ b/puan/ruleset_creator_test.go
@@ -341,6 +341,45 @@ func Test_RulesetCreator_isForbiddenPeriod(t *testing.T) {
 	}
 }
 
+func Test_RulesetCreator_findForbiddenPeriods(t *testing.T) {
+	creator := NewRulesetCreator()
+	creator.forbiddenPeriods = []Period{
+		{
+			from: newTestTime("2024-01-01"),
+			to:   newTestTime("2024-01-10"),
+		},
+	}
+
+	forbiddenPeriod := TimeBoundVariable{
+		variable: fake.New[string](),
+		period: Period{
+			from: newTestTime("2024-01-02"),
+			to:   newTestTime("2024-01-05"),
+		},
+	}
+	allowedPeriod := TimeBoundVariable{
+		variable: fake.New[string](),
+		period: Period{
+			from: newTestTime("2024-01-10"),
+			to:   newTestTime("2024-01-12"),
+		},
+	}
+	periodVariables := TimeBoundVariables{
+		forbiddenPeriod,
+		allowedPeriod,
+	}
+
+	got := creator.findForbiddenPeriods(periodVariables)
+
+	assert.Equal(
+		t,
+		TimeBoundVariables{
+			forbiddenPeriod,
+		},
+		got,
+	)
+}
+
 func Test_AddPrimitives_givenPrimitiveWithPeriodPrefix_shouldReturnError(t *testing.T) {
 	creator := NewRulesetCreator()
 	err := creator.AddPrimitives("period_")

--- a/puan/ruleset_creator_test.go
+++ b/puan/ruleset_creator_test.go
@@ -247,6 +247,17 @@ func Test_RulesetCreator_ForbidPeriod_givenErrorCases_shouldReturnError(t *testi
 	}
 }
 
+func Test_RulesetCreator_ForbidPeriod_givenTimeNotEnabled_shouldReturnError(
+	t *testing.T,
+) {
+	creator := NewRulesetCreator()
+	err := creator.ForbidPeriod(
+		fake.New[time.Time](),
+		fake.New[time.Time](),
+	)
+	assert.ErrorIs(t, err, puanerror.InvalidOperation)
+}
+
 func Test_RulesetCreator_setSingleOrOR_givenNoIDs_shouldReturnError(t *testing.T) {
 	creator := NewRulesetCreator()
 	_, err := creator.setSingleOrOR([]string{}...)

--- a/puan/ruleset_creator_test.go
+++ b/puan/ruleset_creator_test.go
@@ -224,6 +224,123 @@ func Test_RulesetCreator_setSingleOrAND_givenDuplicatedIDs_shouldReturnID(t *tes
 	assert.Equal(t, code, got)
 }
 
+func Test_RulesetCreator_isForbiddenPeriod(t *testing.T) {
+	tests := []struct {
+		name             string
+		forbiddenPeriods []Period
+		periodVariable   TimeBoundVariable
+		want             bool
+	}{
+		{
+			name:             "no forbidden periods, is not forbidden",
+			forbiddenPeriods: nil,
+			periodVariable: TimeBoundVariable{
+				period: Period{
+					from: newTestTime("2024-01-10"),
+					to:   newTestTime("2024-01-12"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "period is fully inside forbidden period, is forbidden",
+			forbiddenPeriods: []Period{
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-31"),
+				},
+			},
+			periodVariable: TimeBoundVariable{
+				period: Period{
+					from: newTestTime("2024-01-10"),
+					to:   newTestTime("2024-01-12"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "partial overlap, is not forbidden",
+			forbiddenPeriods: []Period{
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-10"),
+				},
+			},
+			periodVariable: TimeBoundVariable{
+				period: Period{
+					from: newTestTime("2024-01-09"),
+					to:   newTestTime("2024-01-12"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "none overlap, is not forbidden",
+			forbiddenPeriods: []Period{
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-10"),
+				},
+				{
+					from: newTestTime("2024-01-20"),
+					to:   newTestTime("2024-01-30"),
+				},
+			},
+			periodVariable: TimeBoundVariable{
+				period: Period{
+					from: newTestTime("2024-01-12"),
+					to:   newTestTime("2024-01-18"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "period touching 1 edge, is forbidden",
+			forbiddenPeriods: []Period{
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-10"),
+				},
+			},
+			periodVariable: TimeBoundVariable{
+				period: Period{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-05"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "period touching both edges, is forbidden",
+			forbiddenPeriods: []Period{
+				{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-10"),
+				},
+			},
+			periodVariable: TimeBoundVariable{
+				period: Period{
+					from: newTestTime("2024-01-01"),
+					to:   newTestTime("2024-01-10"),
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			creator := RulesetCreator{
+				forbiddenPeriods: tt.forbiddenPeriods,
+			}
+
+			got := creator.isForbiddenPeriod(tt.periodVariable)
+
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func Test_AddPrimitives_givenPrimitiveWithPeriodPrefix_shouldReturnError(t *testing.T) {
 	creator := NewRulesetCreator()
 	err := creator.AddPrimitives("period_")

--- a/tests/integration_tests/solve/assert.go
+++ b/tests/integration_tests/solve/assert.go
@@ -1,0 +1,40 @@
+package solve
+
+import (
+	"testing"
+
+	"github.com/ourstudio-se/puan-sdk-go/puan"
+	"github.com/stretchr/testify/assert"
+)
+
+type solutionAsserter struct {
+	puan.Solution
+}
+
+func newSolutionAsserter(solution puan.Solution) solutionAsserter {
+	return solutionAsserter{solution}
+}
+
+func (s solutionAsserter) assertActive(t *testing.T, variables ...string) {
+	solution := s.Extract(variables...)
+	for _, variable := range variables {
+		value, ok := solution[variable]
+		if !ok {
+			assert.Failf(t, "variable %s not found in solution", variable)
+		}
+
+		assert.Equal(t, 1, value, "expected %s to be active", variable)
+	}
+}
+
+func (s solutionAsserter) assertInactive(t *testing.T, variables ...string) {
+	solution := s.Extract(variables...)
+	for _, variable := range variables {
+		value, ok := solution[variable]
+		if !ok {
+			assert.Failf(t, "variable %s not found in solution", variable)
+		}
+
+		assert.Equal(t, 0, value, "expected %s to be inactive", variable)
+	}
+}

--- a/tests/integration_tests/solve/period_test.go
+++ b/tests/integration_tests/solve/period_test.go
@@ -500,34 +500,67 @@ func Test_givenXORWithManyPreferredInFirstPeriod_selectNonPreferredItem_shouldCh
 	asserter.assertInactive(t, "period_1")
 }
 
-type solutionAsserter struct {
-	puan.Solution
+func Test_forbiddenPeriod_givenFromInForbiddenPeriod_shouldChoosePeriodAfterForbiddenPeriod(
+	t *testing.T,
+) {
+	minute0 := time.Now().Truncate(time.Minute)
+	minute15 := minute0.Add(15 * time.Minute)
+	minute30 := minute0.Add(30 * time.Minute)
+	minute45 := minute0.Add(45 * time.Minute)
+	minute60 := minute0.Add(1 * time.Hour)
+
+	creator := puan.NewRulesetCreator()
+
+	_ = creator.EnableTime(minute0, minute60)
+
+	_ = creator.ForbidPeriod(
+		minute15,
+		minute45,
+	)
+
+	ruleset, _ := creator.Create()
+
+	envelope, _ := solutionCreator.Create(
+		nil,
+		ruleset,
+		&minute30,
+	)
+	solution := envelope.Solution()
+
+	solverPeriod, _ := ruleset.FindPeriodInSolution(solution)
+
+	assert.Equal(t, minute45, solverPeriod.From())
+	assert.Equal(t, minute60, solverPeriod.To())
 }
 
-func newSolutionAsserter(solution puan.Solution) solutionAsserter {
-	return solutionAsserter{solution}
-}
+func Test_forbiddenPeriod_givenFromBeforeForbiddenPeriod_shouldChoosePeriodThatEndsAtForbiddenPeriod(
+	t *testing.T,
+) {
+	minute0 := time.Now().Truncate(time.Minute)
+	minute15 := minute0.Add(15 * time.Minute)
+	minute45 := minute0.Add(45 * time.Minute)
+	minute60 := minute0.Add(1 * time.Hour)
 
-func (s solutionAsserter) assertActive(t *testing.T, variables ...string) {
-	solution := s.Extract(variables...)
-	for _, variable := range variables {
-		value, ok := solution[variable]
-		if !ok {
-			assert.Failf(t, "variable %s not found in solution", variable)
-		}
+	creator := puan.NewRulesetCreator()
 
-		assert.Equal(t, 1, value, "expected %s to be active", variable)
-	}
-}
+	_ = creator.EnableTime(minute0, minute60)
 
-func (s solutionAsserter) assertInactive(t *testing.T, variables ...string) {
-	solution := s.Extract(variables...)
-	for _, variable := range variables {
-		value, ok := solution[variable]
-		if !ok {
-			assert.Failf(t, "variable %s not found in solution", variable)
-		}
+	_ = creator.ForbidPeriod(
+		minute15,
+		minute45,
+	)
 
-		assert.Equal(t, 0, value, "expected %s to be inactive", variable)
-	}
+	ruleset, _ := creator.Create()
+
+	envelope, _ := solutionCreator.Create(
+		nil,
+		ruleset,
+		nil,
+	)
+	solution := envelope.Solution()
+
+	solverPeriod, _ := ruleset.FindPeriodInSolution(solution)
+
+	assert.Equal(t, minute0, solverPeriod.From())
+	assert.Equal(t, minute15, solverPeriod.To())
 }

--- a/tests/integration_tests/solve/period_test.go
+++ b/tests/integration_tests/solve/period_test.go
@@ -564,3 +564,96 @@ func Test_forbiddenPeriod_givenFromBeforeForbiddenPeriod_shouldChoosePeriodThatE
 	assert.Equal(t, minute0, solverPeriod.From())
 	assert.Equal(t, minute15, solverPeriod.To())
 }
+
+// Time is enabled, from 0 - 60
+// Requires exactly one color: color1 or color2
+// color1 is preferred 0 - 30
+// color2 is preferred 30 - 60
+// 15 - 45 is forbidden
+//
+// Find a solution from 15
+// Since 15 - 45 is forbidden, the solver should choose 45
+// Since the solver chooses 45, color2 should be active
+func Test_forbiddenPeriod_withChangingDefaultColor(
+	t *testing.T,
+) {
+	minute0 := time.Now().Truncate(time.Minute)
+	minute15 := minute0.Add(15 * time.Minute)
+	minute30 := minute0.Add(30 * time.Minute)
+	minute45 := minute0.Add(45 * time.Minute)
+	minute60 := minute0.Add(1 * time.Hour)
+
+	creator := puan.NewRulesetCreator()
+
+	_ = creator.EnableTime(minute0, minute60)
+
+	_ = creator.ForbidPeriod(
+		minute15,
+		minute45,
+	)
+
+	_ = creator.AddPrimitives("color1", "color2")
+	singleColor, _ := creator.SetXor("color1", "color2")
+	_ = creator.Assume(singleColor)
+
+	preferColor1, _ := creator.SetImply(singleColor, "color1")
+	_ = creator.PreferInPeriod(preferColor1, minute0, minute30)
+	preferColor2, _ := creator.SetImply(singleColor, "color2")
+	_ = creator.PreferInPeriod(preferColor2, minute30, minute60)
+
+	ruleset, _ := creator.Create()
+
+	envelope, _ := solutionCreator.Create(
+		nil,
+		ruleset,
+		&minute15,
+	)
+	solution := envelope.Solution()
+
+	asserter := newSolutionAsserter(solution)
+	asserter.assertInactive(t, "color1")
+	asserter.assertActive(t, "color2")
+}
+
+// Time is enabled, from 0 - 60
+// ItemX is forbidden 0 - 30
+// 30 - 60 is forbidden
+//
+// Find a solution with itemX selected
+// Since the time when itemX is available is forbidden,
+// itemX is not selected and the solver chooses the earliest period.
+func Test_forbiddenPeriod_givenSelectedItem_isOnlyAvailableInForbiddenPeriod(
+	t *testing.T,
+) {
+	minute0 := time.Now().Truncate(time.Minute)
+	minute30 := minute0.Add(30 * time.Minute)
+	minute60 := minute0.Add(60 * time.Hour)
+
+	creator := puan.NewRulesetCreator()
+
+	_ = creator.EnableTime(minute0, minute60)
+
+	_ = creator.ForbidPeriod(
+		minute30,
+		minute60,
+	)
+
+	_ = creator.AddPrimitives("itemX")
+	notX, _ := creator.SetNot("itemX")
+	_ = creator.AssumeInPeriod(notX, minute0, minute30)
+
+	ruleset, _ := creator.Create()
+
+	envelope, _ := solutionCreator.Create(
+		puan.Selections{
+			puan.NewSelectionBuilder("itemX").Build(),
+		},
+		ruleset,
+		nil,
+	)
+	solution := envelope.Solution()
+
+	asserter := newSolutionAsserter(solution)
+	asserter.assertInactive(t, "itemX")
+	asserter.assertActive(t, "period_0")
+}

--- a/tests/integration_tests/solve/period_test.go
+++ b/tests/integration_tests/solve/period_test.go
@@ -627,7 +627,7 @@ func Test_forbiddenPeriod_givenSelectedItem_isOnlyAvailableInForbiddenPeriod(
 ) {
 	minute0 := time.Now().Truncate(time.Minute)
 	minute30 := minute0.Add(30 * time.Minute)
-	minute60 := minute0.Add(60 * time.Hour)
+	minute60 := minute0.Add(60 * time.Minute)
 
 	creator := puan.NewRulesetCreator()
 

--- a/tests/integration_tests/solve/period_test.go
+++ b/tests/integration_tests/solve/period_test.go
@@ -533,7 +533,7 @@ func Test_forbiddenPeriod_givenFromInForbiddenPeriod_shouldChoosePeriodAfterForb
 	assert.Equal(t, minute60, solverPeriod.To())
 }
 
-func Test_forbiddenPeriod_givenFromBeforeForbiddenPeriod_shouldChoosePeriodThatEndsAtForbiddenPeriod(
+func Test_forbiddenPeriod_givenFromBeforeForbiddenPeriod_shouldChoosePeriodThatEndsAtStartOfForbiddenPeriod(
 	t *testing.T,
 ) {
 	minute0 := time.Now().Truncate(time.Minute)
@@ -565,7 +565,7 @@ func Test_forbiddenPeriod_givenFromBeforeForbiddenPeriod_shouldChoosePeriodThatE
 	assert.Equal(t, minute15, solverPeriod.To())
 }
 
-// Time is enabled, from 0 - 60
+// Time is enabled: 0 - 60
 // Requires exactly one color: color1 or color2
 // color1 is preferred 0 - 30
 // color2 is preferred 30 - 60
@@ -615,7 +615,7 @@ func Test_forbiddenPeriod_withChangingDefaultColor(
 	asserter.assertActive(t, "color2")
 }
 
-// Time is enabled, from 0 - 60
+// Time is enabled: 0 - 60
 // ItemX is forbidden 0 - 30
 // 30 - 60 is forbidden
 //
@@ -656,4 +656,36 @@ func Test_forbiddenPeriod_givenSelectedItem_isOnlyAvailableInForbiddenPeriod(
 	asserter := newSolutionAsserter(solution)
 	asserter.assertInactive(t, "itemX")
 	asserter.assertActive(t, "period_0")
+}
+
+func Test_forbiddenPeriod_givenRequiredItemOnlyAvailableInForbiddenPeriod_noSolutionCanBeFound(
+	t *testing.T,
+) {
+	minute0 := time.Now().Truncate(time.Minute)
+	minute30 := minute0.Add(30 * time.Minute)
+	minute60 := minute0.Add(60 * time.Minute)
+
+	creator := puan.NewRulesetCreator()
+
+	_ = creator.EnableTime(minute0, minute60)
+
+	_ = creator.ForbidPeriod(
+		minute30,
+		minute60,
+	)
+
+	_ = creator.AddPrimitives("itemX")
+	notX, _ := creator.SetNot("itemX")
+	_ = creator.AssumeInPeriod(notX, minute0, minute30)
+	_ = creator.Assume("itemX")
+
+	ruleset, _ := creator.Create()
+
+	_, err := solutionCreator.Create(
+		nil,
+		ruleset,
+		nil,
+	)
+
+	assert.Error(t, err)
 }


### PR DESCRIPTION
# Description

Add support for `ForbidPeriod` - forbidding a sub period of a ruleset.

# How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [ ] Manually locally

# Checklist:

- [x] My code follows the [style guidelines](https://github.com/uber-go/guide/blob/master/style.md)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code (where needed)
- [ ] I have made corresponding changes to the documentation/README
- [x] My changes generate no new warnings
- [ ] Tests are added for relevant functions
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] Observability is added (where needed)
